### PR TITLE
Add language switcher e2e test

### DIFF
--- a/packages/app-tests/e2e/features/language-switcher.spec.ts
+++ b/packages/app-tests/e2e/features/language-switcher.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+import { seedUser } from '@documenso/prisma/seed/users';
+
+import { apiSignin } from '../fixtures/authentication';
+
+// Test language switcher sets Portuguese and cookie
+
+test('[LANGUAGE_SWITCHER]: selecting Portuguese sets cookie', async ({ page }) => {
+  const { user } = await seedUser();
+
+  await apiSignin({ page, email: user.email });
+
+  // Open the account menu
+  await page.getByTestId('menu-switcher').click();
+  // Open the language switcher dialog
+  await page.getByRole('menuitem', { name: 'Language' }).click();
+
+  // Verify option is present
+  const portugueseOption = page.getByRole('option', { name: 'Portuguese' });
+  await expect(portugueseOption).toBeVisible();
+
+  // Select Portuguese
+  await portugueseOption.click();
+
+  // Wait for language preference to be saved
+  await page.waitForResponse((resp) =>
+    resp.url().includes('/api/locale') && resp.status() === 200,
+  );
+
+  // Check lang cookie
+  const cookies = await page.context().cookies();
+  const langCookie = cookies.find((c) => c.name === 'lang');
+  expect(langCookie?.value).toBe('pt');
+});


### PR DESCRIPTION
## Summary
- add playwright test to verify Portuguese language option and cookie

## Testing
- `npm run test:e2e -w @documenso/app-tests --silent` *(fails: start-server-and-test not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e4395e88832b84c56c59a07ab378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end test to verify that selecting Portuguese in the language switcher updates the language preference and sets the appropriate browser cookie.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->