### PR TITLE
Enable pt-BR locale and documentation

### DIFF
--- a/apps/documentation/pages/developers/local-development/_meta.json
+++ b/apps/documentation/pages/developers/local-development/_meta.json
@@ -4,5 +4,6 @@
   "manual": "Manual Setup",
   "gitpod": "Gitpod",
   "signing-certificate": "Signing Certificate",
-  "translations": "Translations"
+  "translations": "Translations",
+  "stripe": "Local Stripe"
 }

--- a/apps/documentation/pages/developers/local-development/stripe.mdx
+++ b/apps/documentation/pages/developers/local-development/stripe.mdx
@@ -1,0 +1,18 @@
+---
+title: Local Stripe
+description: Running Stripe locally for testing payments.
+---
+
+# Local Stripe Setup
+
+To develop features that rely on Stripe webhooks or billing flows, you can run the Stripe CLI to forward events to your local environment.
+
+```bash
+# Install the Stripe CLI if you don't already have it
+stripe login
+
+# Forward webhooks to your local server
+stripe listen --forward-to localhost:3000/api/webhooks/stripe
+```
+
+For additional details see the [Stripe CLI documentation](https://stripe.com/docs/stripe-cli).

--- a/packages/lib/constants/i18n.ts
+++ b/packages/lib/constants/i18n.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const SUPPORTED_LANGUAGE_CODES = ['de', 'en', 'fr', 'es', 'it', 'pl'] as const;
+export const SUPPORTED_LANGUAGE_CODES = ['de', 'en', 'fr', 'es', 'it', 'pl', 'pt'] as const;
 
 export const ZSupportedLanguageCodeSchema = z.enum(SUPPORTED_LANGUAGE_CODES).catch('en');
 
@@ -53,6 +53,10 @@ export const SUPPORTED_LANGUAGES: Record<string, SupportedLanguage> = {
   pl: {
     short: 'pl',
     full: 'Polish',
+  },
+  pt: {
+    short: 'pt',
+    full: 'Portuguese',
   },
 } satisfies Record<SupportedLanguageCodes, SupportedLanguage>;
 

--- a/packages/lib/translations/pt/web.po
+++ b/packages/lib/translations/pt/web.po
@@ -14,10 +14,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: apps/remix/app/components/dialogs/template-direct-link-dialog.tsx
--msgid " Enable direct link signing"
--msgstr " Habilitar assinatura via link direto"
-+msgid "Enable direct link signing"
-+msgstr "Habilitar assinatura via link direto"
+msgid "Enable direct link signing"
+msgstr "Habilitar assinatura via link direto"
 #: apps/remix/app/components/embed/authoring/configure-document-upload.tsx
 msgid ".PDF documents accepted (max {APP_DOCUMENT_UPLOAD_SIZE_LIMIT}MB)"
 msgstr "Documentos .PDF aceitos (máx {APP_DOCUMENT_UPLOAD_SIZE_LIMIT}MB)"


### PR DESCRIPTION
## Summary
- clean up Portuguese PO file
- include `pt` in supported language lists
- document running Stripe locally
- link the Stripe docs from the _meta.json

## Testing
- `npm ci` *(fails: ENETUNREACH downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687791bbfcf0832bbb02a59a2622cbcc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Portuguese ('pt') as a supported language across the platform.
  * Introduced a new documentation page with setup instructions for using Stripe CLI in local development.

* **Documentation**
  * Expanded local development documentation to include guidance for integrating Stripe.
  * Updated navigation metadata to reference the new Stripe documentation page.

* **Style**
  * Fixed formatting in the Portuguese translation by removing unnecessary leading spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->